### PR TITLE
Overload of NamedGraphs Functions for DataGraph

### DIFF
--- a/src/DataGraphs.jl
+++ b/src/DataGraphs.jl
@@ -104,7 +104,9 @@ import NamedGraphs:
   rename_vertices,
   symrcm,
   symrcm_permute,
-  vertextype
+  vertextype,
+  parent_graph,
+  parent_vertices_to_vertices
 
 # General functions
 not_implemented() = error("Not implemented")

--- a/src/abstractdatagraph.jl
+++ b/src/abstractdatagraph.jl
@@ -90,6 +90,15 @@ for f in [
   end
 end
 
+# NamedGraphs overloads
+for f in [:parent_graph, :parent_vertices_to_vertices]
+  @eval begin
+    function $f(graph::AbstractDataGraph, args...; kwargs...)
+      return $f(underlying_graph(graph), args...; kwargs...)
+    end
+  end
+end
+
 # Fix for ambiguity error with `AbstractGraph` version
 function degree(graph::AbstractDataGraph, vertex::Integer)
   return degree(underlying_graph(graph), vertex)


### PR DESCRIPTION
This is Quick PR to allow a few functions from NamedGraphs.jl to work on a DataGraph.

Specifically these changes allow the functions `parent_graph(dg::DataGraph)` and `parent_vertices_to_vertices(dg::DataGraph, args...)` to work by passing to the `underlying_graph`. This is necessary for upcoming changes to `ITensorNetworks.jl` and I would prefer to do it more generally here than on just the `AbstractITensorNetwork` type.

There is an implicit assumption here that `underlying_graph(dg)` is an `AbstractNamedGraph` as opposed to say a `SimpleGraph` (for which it will error). @mtfishman  I could add an explicit error check for this if you wish? But this is also our assumption going forward in a lot of `ITensorNetworks.jl` code: i.e. that we always work with `AbstractNamedGraphs` and that certain functionality will not work if the `underlying_graph` is a `SimpleGraph` instead. 