### PR TITLE
CompatHelper: bump compat for NamedGraphs to 0.11, (keep existing compat)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "DataGraphs"
 uuid = "b5a273c3-7e6c-41f6-98bd-8d7f1525a36a"
-version = "0.3.17"
+version = "0.3.18"
 authors = ["Matthew Fishman <mfishman@flatironinstitute.org> and contributors"]
 
 [workspace]
@@ -22,6 +22,6 @@ DataGraphsGraphsFlowsExt = "GraphsFlows"
 Dictionaries = "0.4"
 Graphs = "1"
 GraphsFlows = "0.1.1"
-NamedGraphs = "0.10"
+NamedGraphs = "0.10, 0.11"
 SimpleTraits = "0.9"
 julia = "1.7"


### PR DESCRIPTION
This pull request changes the compat entry for the `NamedGraphs` package from `0.10` to `0.10, 0.11`.
This keeps the compat entries for earlier versions.



Note: I have not tested your package with this new compat entry.
It is your responsibility to make sure that your package tests pass before you merge this pull request.