### PR TITLE
CompatHelper: bump compat for NamedGraphs to 0.11 for package examples, (keep existing compat)

### DIFF
--- a/examples/Project.toml
+++ b/examples/Project.toml
@@ -9,4 +9,4 @@ path = ".."
 [compat]
 DataGraphs = "0.3"
 Graphs = "1.12"
-NamedGraphs = "0.10"
+NamedGraphs = "0.10, 0.11"


### PR DESCRIPTION
This pull request changes the compat entry for the `NamedGraphs` package from `0.10` to `0.10, 0.11` for package examples.
This keeps the compat entries for earlier versions.



Note: I have not tested your package with this new compat entry.
It is your responsibility to make sure that your package tests pass before you merge this pull request.