### PR TITLE
`AbstractDataGraph` method `isassigned` now converts vertex/edge input via `convert(graph, ...)`.

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "DataGraphs"
 uuid = "b5a273c3-7e6c-41f6-98bd-8d7f1525a36a"
-version = "0.5.0"
+version = "0.5.1"
 authors = ["Matthew Fishman <mfishman@flatironinstitute.org> and contributors"]
 
 [workspace]

--- a/src/indexing.jl
+++ b/src/indexing.jl
@@ -31,10 +31,13 @@ function isassigned_datagraph(graph::AbstractGraph, inds::AbstractGraphIndices)
     return all(ind -> isassigned(graph, ind), inds)
 end
 
-is_graph_index_assigned(graph::AbstractGraph, vertex) = is_vertex_assigned(graph, vertex)
+function is_graph_index_assigned(graph::AbstractGraph{V}, vertex) where {V}
+    return is_vertex_assigned(graph, convert(V, vertex))
+end
 
 function is_graph_index_assigned(graph::AbstractGraph, edge::AbstractEdge)
-    return is_edge_assigned(graph, arrange_edge(graph, edge))
+    E = edgetype(graph)
+    return is_edge_assigned(graph, convert(E, arrange_edge(graph, edge)))
 end
 
 # ====================================== setindex! ======================================= #

--- a/test/test_basics.jl
+++ b/test/test_basics.jl
@@ -61,6 +61,7 @@ using Test: @test, @test_broken, @testset
         dg[3] = "V3"
         dg[4] = "V4"
         @test isassigned(dg, 1)
+        @test isassigned(dg, 1.0)
         @test dg[1] == "V1"
         @test dg[2] == "V2"
         @test dg[3] == "V3"
@@ -71,7 +72,9 @@ using Test: @test, @test_broken, @testset
         dg[NamedEdge(3, 4)] = :E34
         #@test isassigned(dg, (1, 2))
         @test isassigned(dg, NamedEdge(2, 3))
+        @test isassigned(dg, NamedEdge(2.0, 3.0))
         @test isassigned(dg, 3 => 4)
+        @test isassigned(dg, 3.0 => 4.0)
         @test dg[NamedEdge(1, 2)] == :E12
         @test dg[2 => 3] == :E23
         @test dg[3 => 4] == :E34

--- a/test/test_vertexoredgedatagraph.jl
+++ b/test/test_vertexoredgedatagraph.jl
@@ -104,6 +104,7 @@ using Test: @test, @test_throws, @testset
             @test !isassigned(g, 1)
             @test !isassigned(g, 2)
             @test !isassigned(g, 3)
+            @test !isassigned(g, 3.0)
             add_edge!(g, NamedEdge(1, 2))
             @test !isassigned(g, 1 => 2)
         end
@@ -116,6 +117,7 @@ using Test: @test, @test_throws, @testset
             @test isassigned(g, 1)
             @test isassigned(g, 2)
             @test isassigned(g, 3)
+            @test isassigned(g, 3.0)
             @test g[1] == "V1"
             @test g[2] == "V2"
             @test g[3] == "V3"
@@ -302,6 +304,7 @@ using Test: @test, @test_throws, @testset
             @test edge_data_type(g) == String
             @test !isassigned(g, 1)
             @test !isassigned(g, NamedEdge(1, 2))
+            @test !isassigned(g, NamedEdge(1.0, 2.0))
         end
 
         @testset "setindex! and getindex" begin
@@ -310,6 +313,8 @@ using Test: @test, @test_throws, @testset
             g[NamedEdge(1, 2)] = "E12_updated"
             @test g[NamedEdge(1, 2)] == "E12_updated"
             @test g[NamedEdge(2, 3)] == "E23"
+            @test isassigned(g, NamedEdge(1.0, 2.0 + 0.0im))
+            @test g[NamedEdge(2.0, 3.0)] == "E23"
         end
 
         @testset "rem_edge!" begin


### PR DESCRIPTION
The interface for custom `isassigned` on vertex or edge types that aren't explicitly the basic vertices/edges of the graph is to overload `is_graph_indices_assigned`, therefore this should not interfere with that use case. 